### PR TITLE
Use boost::random::discrete_distribution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DropletUtils
-Version: 1.5.1
-Date: 2019-05-16
+Version: 1.5.2
+Date: 2019-05-20
 Title: Utilities for Handling Single-Cell Droplet Data
 Authors@R: c(
     person("Aaron", "Lun", role = c("aut", "cre"), email = "infinite.monkeys.with.keyboards@gmail.com"), 

--- a/R/emptyDrops.R
+++ b/R/emptyDrops.R
@@ -77,6 +77,12 @@ testEmptyDrops <- function(m, lower=100, niters=10000, test.ambient=FALSE, ignor
 
     pcg.state <- .setup_pcg_state(per.core)
 
+    # Structuring the ambient so that the highest probabilities
+    # are in the middle, to improve the speed of the binary search.
+    re.o <- order(ambient)
+    evens <- seq_along(re.o)%%2==0L
+    ambient <- ambient[c(re.o[evens], rev(re.o[!evens]))]
+
     out.values <- bpmapply(iterations=per.core, seeds=pcg.state$seeds, streams=pcg.state$streams,
         FUN=.monte_carlo_pval, 
         MoreArgs=list(

--- a/R/emptyDrops.R
+++ b/R/emptyDrops.R
@@ -77,12 +77,6 @@ testEmptyDrops <- function(m, lower=100, niters=10000, test.ambient=FALSE, ignor
 
     pcg.state <- .setup_pcg_state(per.core)
 
-    # Structuring the ambient so that the highest probabilities
-    # are in the middle, to improve the speed of the binary search.
-    re.o <- order(ambient)
-    evens <- seq_along(re.o)%%2==0L
-    ambient <- ambient[c(re.o[evens], rev(re.o[!evens]))]
-
     out.values <- bpmapply(iterations=per.core, seeds=pcg.state$seeds, streams=pcg.state$streams,
         FUN=.monte_carlo_pval, 
         MoreArgs=list(

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,11 @@
 \title{DropletUtils News}
 \encoding{UTF-8}
 
+\section{Version 1.6.0}{\itemize{
+\item Switched emptyDrops() to use Boost's discrete_distribution for weighted sampling. 
+This results in some minor stochastic changes to the Monte Carlo p-values.
+}}
+
 \section{Version 1.4.0}{\itemize{
 \item Removed read10xMatrix().
 


### PR DESCRIPTION
... instead of a binary search, when sampling to obtain Monte Carlo p-values. This is motivated by comments at https://support.bioconductor.org/p/121110/ and provides a modest speed boost (75 seconds to 60 seconds for the 4K PBMC data set). More importantly, it simplifies the C++ code a bit.