### PR TITLE
Support library-specific extraction for functions touching molinfo files.

### DIFF
--- a/R/chimericDrops.R
+++ b/R/chimericDrops.R
@@ -5,6 +5,8 @@
 #' @param sample String containing paths to the molecule information HDF5 files, 
 #' produced by CellRanger for 10X Genomics data.
 #' @param barcode.length An integer scalar specifying the length of the cell barcode, see \code{\link{read10xMolInfo}}.
+#' @param use.library An integer vector specifying the library indices for which to extract molecules from \code{sample}.
+#' Alternatively, a character string specifying one or more library types, e.g., \code{"Gene expression"}.
 #' @param ... Further arguments to be passed to \code{removeChimericDrops}.
 #' @param cells Character vector containing cell barcodes, where each entry corresponds to one molecule.
 #' @param umis Integer vector containing encoded UMI sequences, see \code{?\link{encodeSequences}} for details.
@@ -49,6 +51,11 @@
 #' For all molecules with the same UMI within a given cell, we compute the proportion of reads assigned to each molecule and we keep the molecule with a proportion above \code{min.frac}.
 #' If no molecule passes this threshold, the entire set is discarded.
 #'
+#' The \code{use.library} argument can be used to only check for chimeras within a given feature type, e.g., CRISPR tags.
+#' This is most relevant in situations where \code{sample} contains multiple libraries that involve different sets of shared sequences,
+#' such that chimeras are unlikely to form between molecules from different libraries.
+#' Analysis of just one library can be achieved by setting \code{use.library} to the name or index of the desired feature set.
+#'
 #' @author Aaron Lun
 #'
 #' @examples
@@ -67,8 +74,8 @@
 #' \emph{biorXiv}, \url{https://doi.org/10.1101/093237}
 #'
 #' @export
-chimericDrops <- function(sample, barcode.length=NULL, ...) {
-    mol.info <- read10xMolInfo(sample, barcode.length=barcode.length)
+chimericDrops <- function(sample, barcode.length=NULL, use.library=NULL, ...) {
+    mol.info <- .extract_mol_info(sample, barcode.length=barcode.length, use.library=use.library)
     df <- mol.info$data
     removeChimericDrops(df$cell, df$umi, df$gene, df$reads, ref.genes=mol.info$genes, ...)
 }

--- a/R/get10xMolInfoStats.R
+++ b/R/get10xMolInfoStats.R
@@ -1,7 +1,7 @@
 #' @export
 #' @importFrom S4Vectors DataFrame
-get10xMolInfoStats <- function(sample, barcode.length=NULL) {
-    incoming <- read10xMolInfo(sample, barcode.length, get.umi=FALSE)
+get10xMolInfoStats <- function(sample, barcode.length=NULL, use.library=NULL) {
+    incoming <- .extract_mol_info(sample, barcode.length=barcode.length, get.umi=FALSE, use.library=use.library)
 
     out <- .get_cell_ordering(incoming$data$cell, incoming$data$gem_group)
     o <- out$order

--- a/R/read10xMolInfo.R
+++ b/R/read10xMolInfo.R
@@ -168,3 +168,52 @@ read10xMolInfo <- function(sample, barcode.length=NULL, keep.unmapped=FALSE,
     output
 }
 
+#' @importFrom rhdf5 h5read
+.extract_mol_info <- function(..., use.library=NULL, get.library=FALSE, extract.library.info=FALSE, subset.library.features=FALSE) {
+    original.get <- get.library
+    original.extract <- extract.library.info
+
+    if (!is.null(use.library)) {
+        get.library <- TRUE
+        needs.lib.info <- is.character(use.library) || subset.library.features
+        if (needs.lib.info) {
+            extract.library.info <- TRUE
+        }
+    }
+
+    output <- read10xMolInfo(..., get.library=get.library, extract.library.info=extract.library.info)
+
+    has.library <- !is.null(output$data$library)
+
+    if (!is.null(use.library) && has.library) {
+        if (needs.lib.info) {
+            available.lib <- vapply(output$library.info, FUN="[[", i="library_type", FUN.VALUE="")
+            if (is.character(use.library)) {
+                use.library <- which(available.lib %in% use.library) 
+            }
+        }
+
+        output$data <- output$data[output$data$library %in% use.library,,drop=FALSE]
+
+        if (subset.library.features) {
+            all.types <- as.vector(h5read(sample, "/features/feature_type"))
+            output <- .reindex_mol_info_features(output, all.types %in% available.lib)
+        }
+    }
+
+    if (!original.get) {
+        output$data$library <- NULL
+    }
+    if (!original.extract) {
+        output$library.info <- NULL
+    }
+    output
+}
+
+.reindex_mol_info_features <- function(mol.info, keep) {
+    present <- which(keep)
+    mol.info$data$gene <- m <- match(mol.info$data$gene, present)
+    mol.info$data <- mol.info$data[!is.na(m),,drop=FALSE]
+    mol.info$genes <- mol.info$genes[present]
+    mol.info
+}

--- a/R/read10xMolInfo.R
+++ b/R/read10xMolInfo.R
@@ -169,7 +169,9 @@ read10xMolInfo <- function(sample, barcode.length=NULL, keep.unmapped=FALSE,
 }
 
 #' @importFrom rhdf5 h5read
-.extract_mol_info <- function(..., use.library=NULL, get.library=FALSE, extract.library.info=FALSE, subset.library.features=FALSE) {
+.extract_mol_info <- function(sample, ..., use.library=NULL, get.library=FALSE, 
+    extract.library.info=FALSE, subset.library.features=FALSE) 
+{
     original.get <- get.library
     original.extract <- extract.library.info
 
@@ -181,7 +183,7 @@ read10xMolInfo <- function(sample, barcode.length=NULL, keep.unmapped=FALSE,
         }
     }
 
-    output <- read10xMolInfo(..., get.library=get.library, extract.library.info=extract.library.info)
+    output <- read10xMolInfo(sample, ..., get.library=get.library, extract.library.info=extract.library.info)
 
     has.library <- !is.null(output$data$library)
 
@@ -197,7 +199,7 @@ read10xMolInfo <- function(sample, barcode.length=NULL, keep.unmapped=FALSE,
 
         if (subset.library.features) {
             all.types <- as.vector(h5read(sample, "/features/feature_type"))
-            output <- .reindex_mol_info_features(output, all.types %in% available.lib)
+            output <- .reindex_mol_info_features(output, all.types %in% available.lib[use.library])
         }
     }
 

--- a/R/swappedDrops.R
+++ b/R/swappedDrops.R
@@ -6,6 +6,8 @@
 #' produced by CellRanger for 10X Genomics data.
 #' Each file corresponds to one sample in a multiplexed pool.
 #' @param barcode.length An integer scalar specifying the length of the cell barcode, see \code{\link{read10xMolInfo}}.
+#' @param use.library An integer scalar specifying the library index for which to extract molecules from \code{sample}.
+#' Alternatively, a string specifying the library type, e.g., \code{"Gene expression"}.
 #' @param ... Further arguments to be passed to \code{removeSwappedDrops}.
 #' @param cells A list of character vectors containing cell barcodes.
 #' Each vector corresponds to one sample in a multiplexed pool, and each entry of the vector corresponds to one molecule.
@@ -63,14 +65,20 @@
 #' Each molecule information file should contain data from only a single 10X run.
 #' Users should \emph{not} combine multiple samples into a single molecule information file.
 #' The function will emit a warning upon detecting multiple GEM groups from any molecule information file.
-#' Molecules with different GEMs will not be recognised as coming from a different sample, though they will be recognised as being derived from different cell-level libraries.
+#' Molecules with different GEM groups will not be recognised as coming from a different sample, though they will be recognised as being derived from different cell-level libraries.
 #' 
 #' In files produced by CellRanger version 3.0, an additional per-molecule field is present indicating the (c)DNA library from which the molecule was derived.
 #' Library preparation can be performed separately for different features (e.g., antibodies, CRISPR tags) such that one 10X run can contain data from multiple libraries.
 #' This allows for arbitrarily complicated multiplexing schemes - for example, gene expression libraries might be multiplexed together across one set of samples,
 #' while the antibody-derived libraries might be multiplexed across another \emph{different} set of samples.
 #' For simplicity, we assume that multiplexing was performed across the same set of \code{samples} for all libraries therein.
-#' 
+#'
+#' If a different multiplexing scheme was applied for each library type, users can set \code{use.library} to only check for swapping within a given library type(s).
+#' For example, if the multiplexed set of samples for the gene expression libraries is different from the multiplexed set for the CRISPR libraries,
+#' one could run \code{swappedDrops} separately on each set of samples with \code{use.library} set to the corresponding type. 
+#' This avoids having to take the union of both sets of samples for a single \code{swappedDrops} run,
+#' which could detect spurious swaps between samples that were never multiplexed together for the same library type.
+#'
 #' @author
 #' Jonathan Griffiths,
 #' with modifications by Aaron Lun
@@ -96,13 +104,13 @@
 #' \emph{Nat. Commun.} 9, 1:2667.
 #'
 #' @export
-swappedDrops <- function(samples, barcode.length=NULL, ...) {
+swappedDrops <- function(samples, barcode.length=NULL, use.library=NULL, ...) {
     ref.genes <- NULL
     cells <- umis <- genes <- nreads <- vector("list", length(samples))
     names(cells) <- names(samples)
 
     for (i in seq_along(samples)) {
-        mol.info <- read10xMolInfo(samples[i], barcode.length=barcode.length)
+        mol.info <- .extract_mol_info(sample[i], barcode.length=barcode.length, use.library=use.library)
 
         if (is.null(ref.genes)) {
             ref.genes <- mol.info$genes            

--- a/R/swappedDrops.R
+++ b/R/swappedDrops.R
@@ -110,7 +110,7 @@ swappedDrops <- function(samples, barcode.length=NULL, use.library=NULL, ...) {
     names(cells) <- names(samples)
 
     for (i in seq_along(samples)) {
-        mol.info <- .extract_mol_info(sample[i], barcode.length=barcode.length, use.library=use.library)
+        mol.info <- .extract_mol_info(samples[i], barcode.length=barcode.length, use.library=use.library)
 
         if (is.null(ref.genes)) {
             ref.genes <- mol.info$genes            

--- a/man/chimericDrops.Rd
+++ b/man/chimericDrops.Rd
@@ -5,7 +5,7 @@
 \alias{removeChimericDrops}
 \title{Remove chimeric molecules}
 \usage{
-chimericDrops(sample, barcode.length = NULL, ...)
+chimericDrops(sample, barcode.length = NULL, use.library = NULL, ...)
 
 removeChimericDrops(
   cells,
@@ -23,6 +23,9 @@ removeChimericDrops(
 produced by CellRanger for 10X Genomics data.}
 
 \item{barcode.length}{An integer scalar specifying the length of the cell barcode, see \code{\link{read10xMolInfo}}.}
+
+\item{use.library}{An integer vector specifying the library indices for which to extract molecules from \code{sample}.
+Alternatively, a character string specifying one or more library types, e.g., \code{"Gene expression"}.}
 
 \item{...}{Further arguments to be passed to \code{removeChimericDrops}.}
 
@@ -78,6 +81,11 @@ we retain any molecule that has a much greater number of reads compared to all o
 This is based on the expectation that the original non-chimeric molecule will have undergone more rounds of PCR amplification compared to its chimeric offspring, and thus will have higher read coverage.
 For all molecules with the same UMI within a given cell, we compute the proportion of reads assigned to each molecule and we keep the molecule with a proportion above \code{min.frac}.
 If no molecule passes this threshold, the entire set is discarded.
+
+The \code{use.library} argument can be used to only check for chimeras within a given feature type, e.g., CRISPR tags.
+This is most relevant in situations where \code{sample} contains multiple libraries that involve different sets of shared sequences,
+such that chimeras are unlikely to form between molecules from different libraries.
+Analysis of just one library can be achieved by setting \code{use.library} to the name or index of the desired feature set.
 }
 \examples{
 # Mocking up some 10x HDF5-formatted data.

--- a/man/downsampleReads.Rd
+++ b/man/downsampleReads.Rd
@@ -9,7 +9,8 @@ downsampleReads(
   prop,
   barcode.length = NULL,
   bycol = FALSE,
-  features = NULL
+  features = NULL,
+  use.library = NULL
 )
 }
 \arguments{
@@ -23,6 +24,9 @@ All values should lie in [0, 1] specifying the downsampling proportion for the m
 \item{bycol}{A logical scalar indicating whether downsampling should be performed on a column-by-column basis.}
 
 \item{features}{A character vector containing the names of the features on which to perform downsampling.}
+
+\item{use.library}{An integer vector specifying the library indices for which to extract molecules from \code{sample}.
+Alternatively, a character vector specifying the library type(s), e.g., \code{"Gene expression"}.}
 }
 \value{
 A numeric sparse matrix containing the downsampled UMI counts for each gene (row) and barcode (column).
@@ -50,9 +54,11 @@ The total number of reads for each cell after downsampling is guaranteed to be \
 Different proportions can be specified for different cells by setting \code{prop} to a vector, 
 where each proportion corresponds to a cell/GEM combination in the order returned by \code{\link{get10xMolInfoStats}}.
 
-The \code{features} argument is intended for studies with multiple feature type, e.g., antibody capture or CRISPR tags.
+The \code{use.library} argument is intended for studies with multiple feature types, e.g., antibody capture or CRISPR tags.
 As the reads for each feature type are generated in a separate sequencing library, it is generally most appropriate to downsample reads for each feature type separately.
-This can be achieved by setting \code{features} to the names of the features in each set (\emph{not} the names of the feature sets themselves).
+This can be achieved by setting \code{use.library} to the name or index of the desired feature set.
+The features of interest can also be directly specified with \code{features}.
+(This will be intersected with any \code{use.library} choice if both are specified.)
 }
 \examples{
 # Mocking up some 10X HDF5-formatted data.

--- a/man/get10xMolInfoStats.Rd
+++ b/man/get10xMolInfoStats.Rd
@@ -5,12 +5,14 @@
 \description{Compute some basic per-cell statistics from the 10x molecule information file.}
 
 \usage{
-get10xMolInfoStats(sample, barcode.length=NULL)
+get10xMolInfoStats(sample, barcode.length=NULL, use.library=NULL)
 }
 
 \arguments{
 \item{sample}{A string containing the path to the molecule information HDF5 file.}
 \item{barcode.length}{An integer scalar specifying the length of the cell barcode, see \code{\link{read10xMolInfo}}.}
+\item{use.library}{An integer vector specifying the library indices for which to extract molecules from \code{sample}.
+Alternatively, a character vector specifying the library type(s), e.g., \code{"Gene expression"}.}
 }
 
 \value{

--- a/man/maximumAmbience.Rd
+++ b/man/maximumAmbience.Rd
@@ -93,7 +93,7 @@ scaling
 
 # Estimating the maximum contribution to 'y' by 'ambient'.
 contribution <- maximumAmbience(y, ambient, mode="profile")
-DataFrame(ambient=contribution, total=y)
+DataFrame(ambient=drop(contribution), total=y)
 
 }
 \seealso{

--- a/man/swappedDrops.Rd
+++ b/man/swappedDrops.Rd
@@ -5,7 +5,7 @@
 \alias{removeSwappedDrops}
 \title{Clean barcode-swapped droplet data}
 \usage{
-swappedDrops(samples, barcode.length = NULL, ...)
+swappedDrops(samples, barcode.length = NULL, use.library = NULL, ...)
 
 removeSwappedDrops(
   cells,
@@ -25,6 +25,9 @@ produced by CellRanger for 10X Genomics data.
 Each file corresponds to one sample in a multiplexed pool.}
 
 \item{barcode.length}{An integer scalar specifying the length of the cell barcode, see \code{\link{read10xMolInfo}}.}
+
+\item{use.library}{An integer scalar specifying the library index for which to extract molecules from \code{sample}.
+Alternatively, a string specifying the library type, e.g., \code{"Gene expression"}.}
 
 \item{...}{Further arguments to be passed to \code{removeSwappedDrops}.}
 
@@ -96,13 +99,19 @@ These are necessary to simplify downstream processing and are generally acceptab
 Each molecule information file should contain data from only a single 10X run.
 Users should \emph{not} combine multiple samples into a single molecule information file.
 The function will emit a warning upon detecting multiple GEM groups from any molecule information file.
-Molecules with different GEMs will not be recognised as coming from a different sample, though they will be recognised as being derived from different cell-level libraries.
+Molecules with different GEM groups will not be recognised as coming from a different sample, though they will be recognised as being derived from different cell-level libraries.
 
 In files produced by CellRanger version 3.0, an additional per-molecule field is present indicating the (c)DNA library from which the molecule was derived.
 Library preparation can be performed separately for different features (e.g., antibodies, CRISPR tags) such that one 10X run can contain data from multiple libraries.
 This allows for arbitrarily complicated multiplexing schemes - for example, gene expression libraries might be multiplexed together across one set of samples,
 while the antibody-derived libraries might be multiplexed across another \emph{different} set of samples.
 For simplicity, we assume that multiplexing was performed across the same set of \code{samples} for all libraries therein.
+
+If a different multiplexing scheme was applied for each library type, users can set \code{use.library} to only check for swapping within a given library type(s).
+For example, if the multiplexed set of samples for the gene expression libraries is different from the multiplexed set for the CRISPR libraries,
+one could run \code{swappedDrops} separately on each set of samples with \code{use.library} set to the corresponding type. 
+This avoids having to take the union of both sets of samples for a single \code{swappedDrops} run,
+which could detect spurious swaps between samples that were never multiplexed together for the same library type.
 }
 
 \examples{

--- a/tests/testthat/test-molinfo.R
+++ b/tests/testthat/test-molinfo.R
@@ -3,8 +3,8 @@
 
 tmpdir <- tempfile()
 dir.create(tmpdir)
-ngenes <- 20L
 barcode <- 4L
+ngenes <- 20L
 
 set.seed(910)
 test_that("barcode extraction is working correctly", {
@@ -132,10 +132,77 @@ test_that("read10xMolInfo works with silly inputs containing no molecules", {
     out2 <- read10xMolInfo(out.paths)
     expect_identical(out, out2)
    
-    # Checking  that it behaves when there aren't even any genes. 
+    # Checking that it behaves when there aren't even any genes. 
     out.paths <- DropletUtils:::sim10xMolInfo(tmpdir, nsamples=1, nmolecules=0, ngenes=0, swap.frac=0, barcode.length=barcode) 
     out <- read10xMolInfo(out.paths, barcode=barcode)
     expect_identical(nrow(out$data), 0L)
     expect_identical(length(out$genes), 0L)
 })
 
+set.seed(908)
+test_that("Molecule information extraction by library works correctly", {
+    out.path <- DropletUtils:::sim10xMolInfo(tmpdir, barcode=barcode, nsamples=1, version="3")
+
+    # Mocking up multiple libraries.
+    current <- read10xMolInfo(out.path, keep.unmapped=TRUE)
+    permuted <- sample(3, nrow(current$data), replace=TRUE)
+    rhdf5::h5write(permuted - 1L, out.path, "library_idx")
+
+    rhdf5::h5delete(out.path, "library_info")
+    rhdf5::h5write(as.character(jsonlite::toJSON(list(
+         list(library_id=0, library_type="A", gem_group=1),
+         list(library_id=1, library_type="B", gem_group=2),
+         list(library_id=2, library_type="C", gem_group=3)
+     ), auto_unbox=TRUE)), out.path, "library_info")
+
+    feat.types <- sample(LETTERS[1:3], length(current$genes), replace=TRUE)
+    rhdf5::h5write(feat.types, out.path, "features/feature_type")
+
+    # Naive extraction.
+    ref <- read10xMolInfo(out.path, get.library=FALSE)
+    out <- DropletUtils:::.extract_mol_info(out.path)
+    expect_identical(out, ref)
+
+    # Subsetting to the first library. 
+    ref <- read10xMolInfo(out.path, get.library=TRUE)
+
+    out <- DropletUtils:::.extract_mol_info(out.path, use.library=1)
+    sub <- ref$data[ref$data$library == 1,]
+    sub$library <- NULL
+    expect_identical(out$data, sub)
+
+    out <- DropletUtils:::.extract_mol_info(out.path, use.library=c(3, 1))
+    sub <- ref$data[ref$data$library %in% c(1, 3),]
+    sub$library <- NULL
+    expect_identical(out$data, sub)
+
+    # Works with character vectors.
+    out <- DropletUtils:::.extract_mol_info(out.path, use.library="B")
+    sub <- ref$data[ref$data$library == 2,]
+    sub$library <- NULL
+    expect_identical(out$data, sub)
+
+    out <- DropletUtils:::.extract_mol_info(out.path, use.library=c("A", "B"))
+    sub <- ref$data[ref$data$library %in% 1:2,]
+    sub$library <- NULL
+    expect_identical(out$data, sub)
+
+    # Works with subsetting.
+    out <- DropletUtils:::.extract_mol_info(out.path, use.library=2, subset.library.features=TRUE)
+#    sub <- ref$data[ref$data$library == 2 & feat.types[ref$data$gene] %in% "B",]
+#    sub$library <- NULL
+#    expect_identical(out$data, sub)
+    expect_identical(out$genes, ref$genes[feat.types=="B"])
+
+    out <- DropletUtils:::.extract_mol_info(out.path, use.library="C", subset.library.features=TRUE)
+#    sub <- ref$data[ref$data$library == 3,]
+#    sub$library <- NULL
+#    expect_identical(out$data, sub)
+    expect_identical(out$genes, ref$genes[feat.types=="C"])
+
+    # Preserves library information if requested.
+    out <- DropletUtils:::.extract_mol_info(out.path, use.library="A", get.library=TRUE, extract.library.info=TRUE)
+    ref2 <- read10xMolInfo(out.path, extract.library.info=TRUE)
+    ref2$data <- ref2$data[ref2$data$library == 1,]
+    expect_identical(out, ref2)
+})


### PR DESCRIPTION
Allows people to easily apply functions like `swappedDrops` and `downsampleReads` to a particular library type.

Closes #45.