### PR TITLE
Update barcodeRanks.R

### DIFF
--- a/R/barcodeRanks.R
+++ b/R/barcodeRanks.R
@@ -2,7 +2,7 @@
 #' @importFrom stats smooth.spline predict fitted
 #' @importFrom Matrix colSums
 #' @importFrom S4Vectors DataFrame metadata<-
-barcodeRanks <- function(m, lower=100, fit.bounds=NULL, df=20, ...) 
+barcodeRanks <- function(m, lower=100, fit.bounds=NULL, df=20, exclude.from=ncol(m)/2, ...) 
 # Returning statistics to construct a barcode-rank plot. Also calculates
 # the knee and inflection points for further use.
 #
@@ -27,8 +27,8 @@ barcodeRanks <- function(m, lower=100, fit.bounds=NULL, df=20, ...)
     # The upper/lower bounds are defined at the plateau and inflection, respectively.
     d1n <- diff(y)/diff(x)
     
-    # The right edge is calculated on the right 50% of d1n to avoid error for semi-pathologic datasets
-    right.edge <- which.min(d1n[(length(d1n)/2):length(d1n)])
+    # Using the argument exclude.from, the right edge is calculated on the right 50% (by default) of d1n to avoid error for semi-pathologic datasets
+    right.edge <- which.min(d1n[exclude.from:ncol(m)])
     left.edge <- which.max(d1n[seq_len(right.edge)])
 
     # We restrict to this region, thereby simplifying the shape of the curve.

--- a/R/barcodeRanks.R
+++ b/R/barcodeRanks.R
@@ -29,7 +29,7 @@ barcodeRanks <- function(m, lower=100, fit.bounds=NULL, df=20, exclude.from=ncol
     
     # Using the argument exclude.from, the right edge is calculated on the right 50% (by default) of d1n to avoid error for semi-pathologic datasets
     right.edge <- exclude.from + which.min(tail(d1n, length(d1n)-exclude.from))
-    left.edge <- which.max(d1n[seq_len(right.edge)])
+    left.edge <- which.max(d1n[exclude.from:right.edge])
 
     # We restrict to this region, thereby simplifying the shape of the curve.
     # This allows us to get a decent fit with low df for stable differentiation.

--- a/R/barcodeRanks.R
+++ b/R/barcodeRanks.R
@@ -28,7 +28,7 @@ barcodeRanks <- function(m, lower=100, fit.bounds=NULL, df=20, exclude.from=ncol
     d1n <- diff(y)/diff(x)
     
     # Using the argument exclude.from, the right edge is calculated on the right 50% (by default) of d1n to avoid error for semi-pathologic datasets
-    right.edge <- which.min(d1n[exclude.from:ncol(m)])
+    right.edge <- exclude.from + which.min(tail(d1n, length(d1n)-exclude.from))
     left.edge <- which.max(d1n[seq_len(right.edge)])
 
     # We restrict to this region, thereby simplifying the shape of the curve.

--- a/R/barcodeRanks.R
+++ b/R/barcodeRanks.R
@@ -26,7 +26,9 @@ barcodeRanks <- function(m, lower=100, fit.bounds=NULL, df=20, ...)
     # Numerical differentiation to identify bounds for spline fitting.
     # The upper/lower bounds are defined at the plateau and inflection, respectively.
     d1n <- diff(y)/diff(x)
-    right.edge <- which.min(d1n)
+    
+    # The right edge is calculated on the right 50% of d1n to avoid error for semi-pathologic datasets
+    right.edge <- which.min(d1n[(length(d1n)/2):length(d1n)])
     left.edge <- which.max(d1n[seq_len(right.edge)])
 
     # We restrict to this region, thereby simplifying the shape of the curve.

--- a/R/barcodeRanks.R
+++ b/R/barcodeRanks.R
@@ -2,7 +2,7 @@
 #' @importFrom stats smooth.spline predict fitted
 #' @importFrom Matrix colSums
 #' @importFrom S4Vectors DataFrame metadata<-
-barcodeRanks <- function(m, lower=100, fit.bounds=NULL, df=20, exclude.from=ncol(m)/2, ...) 
+barcodeRanks <- function(m, lower=100, fit.bounds=NULL, df=20, exclude.from=100, ...) 
 # Returning statistics to construct a barcode-rank plot. Also calculates
 # the knee and inflection points for further use.
 #


### PR DESCRIPTION
For semi-pathological datasets like this

![image](https://user-images.githubusercontent.com/7232890/88241920-f55c0800-ccce-11ea-85aa-5524c645422e.png)

which provide a d1n like this

![image](https://user-images.githubusercontent.com/7232890/88241998-3522ef80-cccf-11ea-9f07-7b8107c6d824.png)

The algorithms crashes because right.edge ends up on the far left (position 19). Being a bit more conservative and assuming the down-tip of the 2D distribution is located in the right 50% of the d1n we can avoid crashing.