### PR TITLE
Save attributes as UTF-8 variable-len scalar strings.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DropletUtils
-Version: 1.13.0
-Date: 2021-02-20
+Version: 1.13.1
+Date: 2021-05-31
 Title: Utilities for Handling Single-Cell Droplet Data
 Authors@R: c(
     person("Aaron", "Lun", role = c("aut", "cre"), email = "infinite.monkeys.with.keyboards@gmail.com"), 

--- a/R/write10xCounts.R
+++ b/R/write10xCounts.R
@@ -198,9 +198,9 @@ write10xCounts <- function(path, x, barcodes=colnames(x), gene.id=rownames(x), g
         # Writing attributes.
         h5f <- H5Fopen(path)
         h5g <- H5Gopen(h5f, "/")
-        h5writeAttribute(chemistry, h5obj=h5g, name="chemistry_description")
-        h5writeAttribute("matrix", h5obj=h5g, name="filetype")
-        h5writeAttribute(library.ids, h5obj=h5g, name="library_ids")
+        h5writeAttribute(chemistry, h5obj=h5g, name="chemistry_description", variableLengthString=TRUE, asScalar=TRUE, cset="UTF8")
+        h5writeAttribute("matrix", h5obj=h5g, name="filetype", variableLengthString=TRUE, asScalar=TRUE, cset="UTF8")
+        h5writeAttribute(library.ids, h5obj=h5g, name="library_ids", variableLengthString=TRUE, asScalar=TRUE, cset="UTF8")
         h5writeAttribute(original.gem.groups, h5obj=h5g, name="original_gem_groups")
         h5writeAttribute(as.integer(version) - 1L, h5obj=h5g, name="version") # this is probably correct.
         H5Gclose(h5g)


### PR DESCRIPTION
Fixes #40.