### PR TITLE
Add `known.empty` to `emptyDrops`, to facilitate cell calling on multi-modal data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: DropletUtils
-Version: 1.17.4
+Version: 1.19.1
 Date: 2022-11-08
 Title: Utilities for Handling Single-Cell Droplet Data
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DropletUtils
 Version: 1.19.1
-Date: 2022-11-08
+Date: 2022-11-21
 Title: Utilities for Handling Single-Cell Droplet Data
 Authors@R: c(
     person("Aaron", "Lun", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DropletUtils
-Version: 1.17.3
-Date: 2022-09-21
+Version: 1.17.4
+Date: 2022-11-08
 Title: Utilities for Handling Single-Cell Droplet Data
 Authors@R: c(
     person("Aaron", "Lun", role = "aut"),

--- a/R/ambientProfileEmpty.R
+++ b/R/ambientProfileEmpty.R
@@ -7,6 +7,7 @@
 #' @inheritParams emptyDrops
 #' @param by.rank An optional integer scalar, used as an alternative to \code{lower} to identifying assumed empty droplets - see Details.
 #' @param good.turing Logical scalar indicating whether to perform Good-Turing estimation of the proportions.
+#' @param known.empty an optional integer vector indexing barcodes that will be assumed to be empty, over-riding \code{lower} and \code{by.rank}.
 #' @param ... For the generic, further arguments to pass to individual methods.
 #'
 #' For the SummarizedExperiment method, further arguments to pass to the ANY method.
@@ -46,7 +47,13 @@
 #' This specifies the number of barcodes with the highest total counts to ignore; the remaining barcodes are assumed to be ambient.
 #' The idea is that, even if the exact threshold is unknown, we can be certain that a given experiment does not contain more than a particular number of genuine cell-containing barcodes based on the number of cells that were loaded into the machine.
 #' By setting \code{by.rank} to something greater than this \emph{a priori} known number, we exclude the most likely candidates and use the remaining barcodes to compute the ambient profile.
-#'
+#' 
+#' Another alternative when working with some multimodal data, such as CITE-seq could be to use statistics from one modality 
+#' (e.g. mRNA counts) to define empty droplets in the other modality (e.g. CITE-seq)
+#' or combining CITE-seq with mRNA-counts.  In this case, one may set \code{known.empty} to an integer vector indexing 
+#' barcodes in columns of `m`.  For the purpose of retaining cells, if \code{lower} is set, it will be passed on \code{barcodeRanks}, 
+#' otherwise the median of total counts of barcodes that have \code{known.empty} set will be used.
+#' 
 #' @return
 #' A numeric vector of length equal to \code{nrow(m)},
 #' containing the estimated proportion of each transcript in the ambient solution.
@@ -85,13 +92,6 @@ NULL
 
     m <- .rounded_to_integer(m, round)
     totals <- .intColSums(m)
-    
-    if(!is.null(known.empty)){
-        if(!is.integer(known.empty) || any(known.empty < 1) || any(known.empty > ncol(m)) || any(duplicated(known.empty))) 
-          stop("'known.empty' must be distinct, positive integers that index the barcodes.")
-        if(!is.null(by.rank)) warning("Ignoring 'by.rank' when 'known.empty' is set.")
-        if(!is.null(lower)) warning("Ignoring 'lower' when 'known.empty' is set.")
-    }
     
     assumed.empty = .get_putative_empty(totals, lower, by.rank, known.empty)
 
@@ -141,27 +141,39 @@ estimateAmbience <- function(...) {
     )
 }
 
+# inverse of `which(x)`
 inv.which <- function(i, len, useNames = TRUE)
-  setNames('[<-'(logical(len), i, TRUE), if (useNames)
+  stats::setNames('[<-'(logical(len), i, TRUE), if (useNames)
     names(i)
     else
       NULL)
 
 .get_putative_empty <- function(totals, lower, by.rank, known.empty) {
-    if (is.null(by.rank) && is.null(known.empty)) {
-        assumed.empty <- totals <= lower
-    } else if (!is.null(known.empty)) {
-        assumed.empty <- inv.which(known.empty, length(totals))
-        lower <- NA_integer_
-    } else if (by.rank >= length(totals)) {
-        stop("not have enough columns for supplied 'by.rank'")
-    } else {
-        #by.rank non null
-        rt <- rank(-totals, ties.method = "first")
-        assumed.empty <- rt > by.rank
-        lower <- max(totals[rt > by.rank])
+    if (!is.null(known.empty)) {
+      if (!is.integer(known.empty) || any(known.empty < 1) || any(known.empty > length(totals)) || any(duplicated(known.empty)))
+        stop("If specified, 'known.empty' must be distinct, positive integers that index the barcodes.")
+      if (!is.null(by.rank))
+        warning("Ignoring 'by.rank' when 'known.empty' is set.")
+      if (!is.null(lower))
+        message(
+          "When 'known.empty' is set, 'lower' is only used to mark droplets for unconditional retention via `barcodeRanks(...)`."
+        )
     }
-    return(structure(assumed.empty, lower=lower))
+    if (is.null(by.rank) && is.null(known.empty)) {
+      assumed.empty <- totals <= lower
+    } else if (!is.null(known.empty)) {
+      assumed.empty <- inv.which(known.empty, length(totals))
+      if (is.null(lower))
+        lower <- median(totals[assumed.empty])
+    } else if (by.rank >= length(totals)) {
+      stop("not have enough columns for supplied 'by.rank'")
+    } else {
+      #by.rank non null
+      rt <- rank(-totals, ties.method = "first")
+      assumed.empty <- rt > by.rank
+      lower <- max(totals[rt > by.rank])
+    }
+    return(structure(assumed.empty, lower = lower))
 }
 
 #' @importFrom edgeR goodTuringProportions

--- a/R/ambientProfileEmpty.R
+++ b/R/ambientProfileEmpty.R
@@ -48,11 +48,10 @@
 #' The idea is that, even if the exact threshold is unknown, we can be certain that a given experiment does not contain more than a particular number of genuine cell-containing barcodes based on the number of cells that were loaded into the machine.
 #' By setting \code{by.rank} to something greater than this \emph{a priori} known number, we exclude the most likely candidates and use the remaining barcodes to compute the ambient profile.
 #' 
-#' Another alternative when working with some multimodal data, such as CITE-seq could be to use statistics from one modality 
-#' (e.g. mRNA counts) to define empty droplets in the other modality (e.g. CITE-seq)
-#' or combining CITE-seq with mRNA-counts.  In this case, one may set \code{known.empty} to an integer vector indexing 
-#' barcodes in columns of `m`.  For the purpose of retaining cells, if \code{lower} is set, it will be passed on \code{barcodeRanks}, 
-#' otherwise the median of total counts of barcodes that have \code{known.empty} set will be used.
+#' Another alternative when working with some multimodal data, such as CITE-seq, could be to use statistics from one modality (e.g. mRNA counts) to define empty droplets in the other modality (e.g. CITE-seq) or combining CITE-seq with mRNA-counts.
+#' In this case, one may set \code{known.empty} to an integer vector indexing barcodes in columns of `m` to mark cells for the ambient pool.
+#' For the purpose of retaining cells, if \code{lower} is set, it will be used to define the pool of ambient RNA in \code{barcodeRanks}.
+#' Otherwise the median of total counts of barcodes that have \code{known.empty} set will be used in its place.
 #' 
 #' @return
 #' A numeric vector of length equal to \code{nrow(m)},
@@ -93,7 +92,7 @@ NULL
     m <- .rounded_to_integer(m, round)
     totals <- .intColSums(m)
     
-    assumed.empty = .get_putative_empty(totals, lower, by.rank, known.empty)
+    assumed.empty <- .get_putative_empty(totals, lower, by.rank, known.empty)
 
     if (good.turing) {
         a <- .compute_ambient_stats(m, totals, assumed.empty)

--- a/R/emptyDrops.R
+++ b/R/emptyDrops.R
@@ -21,7 +21,8 @@
 #' @param round Logical scalar indicating whether to check for non-integer values in \code{m} and, if present, round them for ambient profile estimation (see \code{?\link{ambientProfileEmpty}}) and the multinomial simulations.
 #' @param assay.type Integer or string specifying the assay containing the count matrix.
 #' @param ... For the generic, further arguments to pass to individual methods.
-#' @param known.empty an optional integer vector indexing barcodes that will be assumed to be empty, e.g. to estimate ambience or emptiness for citeseq data by using mRNA totals to define empty droplets.
+#' @param known.empty an optional integer vector indexing barcodes that will be assumed to be empty, over-riding \code{lower} and \code{by.rank}. 
+#' See \code{?\link{ambientProfileEmpty}} for more details.
 #'
 #' For the SummarizedExperiment method, further arguments to pass to the ANY method.
 #'

--- a/R/emptyDrops.R
+++ b/R/emptyDrops.R
@@ -21,6 +21,7 @@
 #' @param round Logical scalar indicating whether to check for non-integer values in \code{m} and, if present, round them for ambient profile estimation (see \code{?\link{ambientProfileEmpty}}) and the multinomial simulations.
 #' @param assay.type Integer or string specifying the assay containing the count matrix.
 #' @param ... For the generic, further arguments to pass to individual methods.
+#' @param known.empty an optional integer vector indexing barcodes that will be assumed to be empty, e.g. to estimate ambience or emptiness for citeseq data by using mRNA totals to define empty droplets.
 #'
 #' For the SummarizedExperiment method, further arguments to pass to the ANY method.
 #'
@@ -179,11 +180,11 @@ NULL
 
 #' @export
 #' @rdname emptyDrops
-testEmptyDrops <- function(m, lower=100, niters=10000, test.ambient=FALSE, ignore=NULL, alpha=NULL, round=TRUE, by.rank=NULL, BPPARAM=SerialParam()) {
+testEmptyDrops <- function(m, lower=100, niters=10000, test.ambient=FALSE, ignore=NULL, alpha=NULL, round=TRUE, by.rank=NULL, known.empty=NULL, BPPARAM=SerialParam()) {
     ambfun <- function(mat, totals) {
-        lower <- .get_lower(totals, lower, by.rank=by.rank)
-        astats <- .compute_ambient_stats(mat, totals, lower=lower)
-        astats$metadata <- list(lower = lower)
+        assumed.empty <- .get_putative_empty(totals, lower, by.rank, known.empty)
+        astats <- .compute_ambient_stats(mat, totals, assumed.empty)
+        astats$metadata <- list(lower = attr(assumed.empty, "lower"))
         astats$keep <- !astats$ambient
         astats
     }

--- a/man/ambientProfileEmpty.Rd
+++ b/man/ambientProfileEmpty.Rd
@@ -15,6 +15,7 @@ ambientProfileEmpty(m, ...)
   m,
   lower = 100,
   by.rank = NULL,
+  known.empty = NULL,
   round = TRUE,
   good.turing = TRUE,
   BPPARAM = SerialParam()
@@ -38,7 +39,9 @@ For \code{emptyDrops}, this may also be a \linkS4class{SummarizedExperiment} obj
 \item{lower}{A numeric scalar specifying the lower bound on the total UMI count, 
 at or below which all barcodes are assumed to correspond to empty droplets.}
 
-\item{by.rank}{An integer scalar or vector of length 2, used as an alternative to \code{lower} to identifying assumed empty droplets - see Details.}
+\item{by.rank}{An optional integer scalar, used as an alternative to \code{lower} to identifying assumed empty droplets - see Details.}
+
+\item{known.empty}{an optional integer vector indexing barcodes that will be assumed to be empty, over-riding \code{lower} and \code{by.rank}.}
 
 \item{round}{Logical scalar indicating whether to check for non-integer values in \code{m} and, if present, round them for ambient profile estimation (see \code{?\link{ambientProfileEmpty}}) and the multinomial simulations.}
 
@@ -95,6 +98,12 @@ In such cases, an alternative approach can be used by passing an integer to the 
 This specifies the number of barcodes with the highest total counts to ignore; the remaining barcodes are assumed to be ambient.
 The idea is that, even if the exact threshold is unknown, we can be certain that a given experiment does not contain more than a particular number of genuine cell-containing barcodes based on the number of cells that were loaded into the machine.
 By setting \code{by.rank} to something greater than this \emph{a priori} known number, we exclude the most likely candidates and use the remaining barcodes to compute the ambient profile.
+
+Another alternative when working with some multimodal data, such as CITE-seq could be to use statistics from one modality 
+(e.g. mRNA counts) to define empty droplets in the other modality (e.g. CITE-seq)
+or combining CITE-seq with mRNA-counts.  In this case, one may set \code{known.empty} to an integer vector indexing 
+barcodes in columns of `m`.  For the purpose of retaining cells, if \code{lower} is set, it will be passed on \code{barcodeRanks}, 
+otherwise the median of total counts of barcodes that have \code{known.empty} set will be used.
 }
 
 \examples{

--- a/man/emptyDrops.Rd
+++ b/man/emptyDrops.Rd
@@ -16,6 +16,7 @@ testEmptyDrops(
   alpha = NULL,
   round = TRUE,
   by.rank = NULL,
+  known.empty = NULL,
   BPPARAM = SerialParam()
 )
 
@@ -57,13 +58,16 @@ at or below which all barcodes are assumed to correspond to empty droplets.}
 \item{by.rank}{An integer scalar parametrizing an alternative method for identifying assumed empty droplets - see \code{?\link{ambientProfileEmpty}} for more details.
 If set, this is used to redefine \code{lower} and any specified value for \code{lower} is ignored.}
 
-\item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating whether parallelization should be used.}
-
-\item{...}{For the generic, further arguments to pass to individual methods.
+\item{known.empty}{an optional integer vector indexing barcodes that will be assumed to be empty, over-riding \code{lower} and \code{by.rank}. 
+See \code{?\link{ambientProfileEmpty}} for more details.
 
 For the SummarizedExperiment method, further arguments to pass to the ANY method.
 
 For the ANY method, further arguments to pass to \code{testEmptyDrops}.}
+
+\item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating whether parallelization should be used.}
+
+\item{...}{For the generic, further arguments to pass to individual methods.}
 
 \item{retain}{A numeric scalar specifying the threshold for the total UMI count above which all barcodes are assumed to contain cells.}
 

--- a/tests/testthat/test-empty.R
+++ b/tests/testthat/test-empty.R
@@ -377,6 +377,22 @@ test_that("emptyDrops works with by.rank=TRUE", {
     expect_identical(e.out$FDR, e.out2$FDR)
 })
 
+test_that("emptyDrops with with known.empty", {
+  my.counts <- DropletUtils:::simCounts() 
+  
+  set.seed(999)
+  known.empty = which(colSums(my.counts)<=100)
+  out <- emptyDrops(my.counts, lower=100, retain=Inf) # lower
+  
+  set.seed(999)
+  expect_message(ref <- emptyDrops(my.counts, known.empty=known.empty, retain=Inf, lower=100))
+  expect_identical(out, ref)
+  
+  expect_error(emptyDrops(my.counts, known.empty = rep(TRUE, 10), lower = NULL))
+  expect_error(emptyDrops(my.counts, known.empty = runif(n=ncol(my.counts))+10, lower = NULL))
+  expect_warning(ambientProfileEmpty(my.counts, known.empty = known.empty, lower = NULL, by.rank = 10))
+})
+
 set.seed(80002)
 test_that("emptyDrops realizes HDF5Arrays properly", {
     my.counts <- DropletUtils:::simCounts() 


### PR DESCRIPTION
With citeseq data, it might be desirable to estimate the ambient pool of citeseq using the mRNA totals to select putative empty drops, rather than statistics calculated on citeseq totals.  This PR adds an argument that allows specifying the assumed-empty droplets by integer index, which are then treated as ambient otherwise.  To do this, I refactored `.get_lower` to return an index of ambient droplets, rather than the threshold on the totals.  Thus encompassing `by.rank` and `lower` as well.

We're passing R CMD check on bioconductor devel, and I added a couple of unit tests to cover the new argument.